### PR TITLE
Reduce cuda memory use

### DIFF
--- a/geometrycrafter/diff_ppl.py
+++ b/geometrycrafter/diff_ppl.py
@@ -147,13 +147,13 @@ class GeometryCrafterDiffPipeline(StableVideoDiffusionPipeline):
         intrinsic_map = torch.norm(intrinsic_map[:, 2:4], p=2, dim=1, keepdim=False)
 
         for i in range(0, T, chunk_size):
-            latent_dist = self.vae.encode(psedo_image[i : i + chunk_size].to(self.vae.dtype)).latent_dist
+            latent_dist = self.vae.encode(psedo_image[i : i + chunk_size].to("cuda", self.vae.dtype)).latent_dist
             latent_dist = point_map_vae.encode(                
                 torch.cat([
                     intrinsic_map[i:i+chunk_size, None],
                     point_map[i:i+chunk_size, 2:3], 
                     disparity[i:i+chunk_size, None], 
-                    valid_mask[i:i+chunk_size, None]], dim=1),
+                    valid_mask[i:i+chunk_size, None]], dim=1).to("cuda"),
                 latent_dist
             )
             if isinstance(latent_dist, DiagonalGaussianDistribution):

--- a/geometrycrafter/diff_ppl.py
+++ b/geometrycrafter/diff_ppl.py
@@ -179,9 +179,9 @@ class GeometryCrafterDiffPipeline(StableVideoDiffusionPipeline):
                 lat,           
                 num_frames=lat.shape[0],
             )
-            rec_intrinsic_maps.append(rec_imap)
-            rec_depth_maps.append(rec_dmap)
-            rec_valid_masks.append(rec_vmask)
+            rec_intrinsic_maps.append(rec_imap.cpu())
+            rec_depth_maps.append(rec_dmap.cpu())
+            rec_valid_masks.append(rec_vmask.cpu())
         
         rec_intrinsic_maps = torch.cat(rec_intrinsic_maps, dim=0)
         rec_depth_maps = torch.cat(rec_depth_maps, dim=0)

--- a/third_party/__init__.py
+++ b/third_party/__init__.py
@@ -17,6 +17,6 @@ class MoGe(nn.Module):
     def forward_image(self, image: torch.Tensor, **kwargs):
         # image: b, 3, h, w 0,1
         output = self.model.infer(image, resolution_level=9, apply_mask=False, **kwargs)
-        points = output['points'] # b,h,w,3
-        masks = output['mask'] # b,h,w
+        points = output['points'].cpu() # b,h,w,3
+        masks = output['mask'].cpu() # b,h,w
         return points, masks


### PR DESCRIPTION
This PR Reduces CUDA memory use by:

1. Not saving all frames of the full resolution depth estimation on to the GPU.
2. By only moving the downscaled depth estimations to the GPU when it is about to be used on the GPU.